### PR TITLE
Fix the HTTP Request to send many maessages instead of just one.

### DIFF
--- a/airbyte-integrations/connectors/source-http-request/source_http_request/source.py
+++ b/airbyte-integrations/connectors/source-http-request/source_http_request/source.py
@@ -83,10 +83,10 @@ class HttpRequest(HttpStream):
     def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
         if self._response_format == "csv":
             decoded = response.content.decode('utf-8')
-            data = csv.DictReader(decoded.splitlines(), delimiter=self_delimiter)
-            resp = {"type": "RECORD", "value": list(data)}
-            record = AirbyteRecordMessage(stream="http_request", data=resp, emitted_at=int(datetime.now().timestamp()) * 1000)
-            yield AirbyteMessage(type=Type.RECORD, record=record)
+            data = csv.DictReader(decoded.splitlines(), delimiter=self._response_delimiter)
+            for row in data:
+                record = AirbyteRecordMessage(stream="http_request", data=row, emitted_at=int(datetime.now().timestamp()) * 1000)
+                yield AirbyteMessage(type=Type.RECORD, record=record)
         elif self._response_format == "json":
             yield response.json()
         else:


### PR DESCRIPTION
This PR fixes the `HTTP Request` connector to send many messages when is collecting the data instead of sending just one big message in the end. The reason to send many messages instead of a big one is a Snowflake limitation to receive big data.